### PR TITLE
Accept mail arriving through the relay tunnel

### DIFF
--- a/bin/php
+++ b/bin/php
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 APP_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
-${APP_DIR}/php/bin/php.sh -c ${APP_DIR}/config/php/php.ini $@
+DATA_DIR=${SNAP_DATA:-/var${APP_DIR}}
+${APP_DIR}/php/bin/php.sh -c ${DATA_DIR}/config/php/php.ini "$@"

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -13,3 +13,5 @@ CGO_ENABLED=0 go build -buildvcs=false -o "$OUT_HOOKS/configure"    ./cmd/config
 CGO_ENABLED=0 go build -buildvcs=false -o "$OUT_HOOKS/pre-refresh"  ./cmd/pre-refresh
 CGO_ENABLED=0 go build -buildvcs=false -o "$OUT_HOOKS/post-refresh" ./cmd/post-refresh
 CGO_ENABLED=0 go build -buildvcs=false -o "$OUT_BIN/cli"            ./cmd/cli
+
+CGO_ENABLED=0 go build -buildvcs=false -o ../build/smtp                ./cmd/smtp

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -2,6 +2,8 @@
 DIR=$(cd "$(dirname "$0")" && pwd)
 cd "$DIR"
 
+go test ./...
+
 OUT_HOOKS=../build/snap/meta/hooks
 OUT_BIN=../build/snap/bin
 mkdir -p "$OUT_HOOKS" "$OUT_BIN"

--- a/cli/cmd/smtp/main.go
+++ b/cli/cmd/smtp/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	socket := flag.String("socket", "", "unix socket the tunnel delivers to")
+	from := flag.String("from", "", "sender")
+	recipient := flag.String("rcpt", "", "recipient")
+	subject := flag.String("subject", "", "subject, delivery is skipped when empty")
+	body := flag.String("body", "", "message body")
+	repeat := flag.Int("repeat", 1, "how many lines the body is repeated to")
+	flag.Parse()
+
+	if *socket == "" || *from == "" || *recipient == "" {
+		fmt.Fprintln(os.Stderr, "socket, from and rcpt are required")
+		os.Exit(2)
+	}
+
+	session, err := Dial(*socket)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot reach %s: %v\n", *socket, err)
+		os.Exit(1)
+	}
+	defer session.Close()
+
+	text := *body
+	if *repeat > 1 {
+		text = strings.TrimSuffix(strings.Repeat(*body+"\n", *repeat), "\n")
+	}
+
+	deliverErr := session.Deliver(*from, *recipient, *subject, text)
+	fmt.Print(session.Transcript())
+	if deliverErr != nil {
+		fmt.Fprintf(os.Stderr, "conversation failed: %v\n", deliverErr)
+		os.Exit(1)
+	}
+}

--- a/cli/cmd/smtp/session.go
+++ b/cli/cmd/smtp/session.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+const timeout = 20 * time.Second
+
+type Session struct {
+	connection net.Conn
+	reader     *bufio.Reader
+	transcript strings.Builder
+}
+
+func Dial(socket string) (*Session, error) {
+	connection, err := net.DialTimeout("unix", socket, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if err := connection.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
+	session := &Session{connection: connection, reader: bufio.NewReader(connection)}
+	if err := session.reply(); err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+func (s *Session) Close() {
+	_ = s.connection.Close()
+}
+
+func (s *Session) Transcript() string {
+	return s.transcript.String()
+}
+
+func (s *Session) Send(line string) error {
+	if err := s.write(line); err != nil {
+		return err
+	}
+	return s.reply()
+}
+
+func (s *Session) Write(line string) error {
+	return s.write(line)
+}
+
+func (s *Session) write(line string) error {
+	s.transcript.WriteString("> " + line + "\n")
+	_, err := io.WriteString(s.connection, line+"\r\n")
+	return err
+}
+
+func (s *Session) reply() error {
+	for {
+		line, err := s.reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		s.transcript.WriteString("< " + line + "\n")
+		if len(line) < 4 || line[3] != '-' {
+			return nil
+		}
+	}
+}
+
+func (s *Session) Deliver(from string, recipient string, subject string, body string) error {
+	if err := s.Send("EHLO smtp.test"); err != nil {
+		return err
+	}
+	if err := s.Send(fmt.Sprintf("MAIL FROM:<%s>", from)); err != nil {
+		return err
+	}
+	if err := s.Send(fmt.Sprintf("RCPT TO:<%s>", recipient)); err != nil {
+		return err
+	}
+	if subject != "" {
+		if err := s.Send("DATA"); err != nil {
+			return err
+		}
+		if err := s.Write(fmt.Sprintf("Subject: %s", subject)); err != nil {
+			return err
+		}
+		if err := s.Write(fmt.Sprintf("From: %s", from)); err != nil {
+			return err
+		}
+		if err := s.Write(fmt.Sprintf("To: %s", recipient)); err != nil {
+			return err
+		}
+		if err := s.Write(""); err != nil {
+			return err
+		}
+		for _, line := range strings.Split(body, "\n") {
+			if err := s.Write(line); err != nil {
+				return err
+			}
+		}
+		if err := s.Send("."); err != nil {
+			return err
+		}
+	}
+	return s.Send("QUIT")
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,15 +2,19 @@ module hooks
 
 require (
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.11.1
 	github.com/syncloud/golib v1.1.21
 	go.uber.org/zap v1.26.0
 	gopkg.in/ini.v1 v1.67.3
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.21

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,7 +3,7 @@ module hooks
 require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.11.1
-	github.com/syncloud/golib v1.1.21
+	github.com/syncloud/golib v1.1.22
 	go.uber.org/zap v1.26.0
 	gopkg.in/ini.v1 v1.67.3
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -20,14 +20,15 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/syncloud/golib v1.1.21 h1:UpNlcB0lREN3TrZaeCidskutEdArt1oQMgU4/eoBpn8=
-github.com/syncloud/golib v1.1.21/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
+github.com/syncloud/golib v1.1.22 h1:VOS6Hzyo0pqx4vA2nnEDDTSC6FscBf92F/94hCCXw2M=
+github.com/syncloud/golib v1.1.22/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
 gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -78,7 +78,7 @@ func New(logger *zap.Logger) *Installer {
 		platformClient:  platformClient,
 		database:        NewDatabase(appDir, dataDir, configPath, DbName, DbUser, DbPass, PsqlPort, executor, logger),
 		relay:           NewRelay(appDir, configPath, executor, logger),
-		mailInbound:     NewMailInbound(dataDir, platform.NewHttpClient(), logger),
+		mailInbound:     NewMailInbound(dataDir, platformClient, logger),
 		executor:        executor,
 		logger:          logger,
 	}

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -54,6 +54,7 @@ type Installer struct {
 	platformClient  *platform.Client
 	database        *Database
 	relay           *Relay
+	mailInbound     *MailInbound
 	executor        *Executor
 	logger          *zap.Logger
 }
@@ -77,6 +78,7 @@ func New(logger *zap.Logger) *Installer {
 		platformClient:  platformClient,
 		database:        NewDatabase(appDir, dataDir, configPath, DbName, DbUser, DbPass, PsqlPort, executor, logger),
 		relay:           NewRelay(appDir, configPath, executor, logger),
+		mailInbound:     NewMailInbound(dataDir, platform.NewHttpClient(), logger),
 		executor:        executor,
 		logger:          logger,
 	}
@@ -257,11 +259,17 @@ func (i *Installer) Install() error {
 	if err := i.InitConfig(); err != nil {
 		return err
 	}
+	if err := i.mailInbound.Register(); err != nil {
+		return err
+	}
 	return i.database.Init()
 }
 
 func (i *Installer) PostRefresh() error {
 	if err := i.InitConfig(); err != nil {
+		return err
+	}
+	if err := i.mailInbound.Register(); err != nil {
 		return err
 	}
 	return i.database.Rebuild()

--- a/cli/installer/mail_inbound.go
+++ b/cli/installer/mail_inbound.go
@@ -1,10 +1,7 @@
 package installer
 
 import (
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
+	"errors"
 	"path"
 
 	"github.com/syncloud/golib/platform"
@@ -13,14 +10,18 @@ import (
 
 const TunnelSocket = "spool/public/tunnel"
 
-type MailInbound struct {
-	dataDir string
-	client  platform.HttpClient
-	logger  *zap.Logger
+type PlatformRegistry interface {
+	RegisterMailInbound(socket string) error
 }
 
-func NewMailInbound(dataDir string, client platform.HttpClient, logger *zap.Logger) *MailInbound {
-	return &MailInbound{dataDir: dataDir, client: client, logger: logger}
+type MailInbound struct {
+	dataDir  string
+	registry PlatformRegistry
+	logger   *zap.Logger
+}
+
+func NewMailInbound(dataDir string, registry PlatformRegistry, logger *zap.Logger) *MailInbound {
+	return &MailInbound{dataDir: dataDir, registry: registry, logger: logger}
 }
 
 func (m *MailInbound) SocketPath() string {
@@ -30,20 +31,10 @@ func (m *MailInbound) SocketPath() string {
 func (m *MailInbound) Register() error {
 	socket := m.SocketPath()
 	m.logger.Info("registering the inbound mail socket", zap.String("socket", socket))
-	resp, err := m.client.Post("http://unix/mail/inbound/register",
-		url.Values{"socket": {socket}})
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
+	err := m.registry.RegisterMailInbound(socket)
+	if errors.Is(err, platform.ErrNotSupported) {
 		m.logger.Info("this platform does not take inbound mail registrations")
 		return nil
 	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unable to register the inbound mail socket: %s %s",
-			resp.Status, string(body))
-	}
-	return nil
+	return err
 }

--- a/cli/installer/mail_inbound.go
+++ b/cli/installer/mail_inbound.go
@@ -1,0 +1,45 @@
+package installer
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/syncloud/golib/platform"
+	"go.uber.org/zap"
+)
+
+const TunnelSocket = "spool/public/tunnel"
+
+type MailInbound struct {
+	dataDir string
+	client  platform.HttpClient
+	logger  *zap.Logger
+}
+
+func NewMailInbound(dataDir string, client platform.HttpClient, logger *zap.Logger) *MailInbound {
+	return &MailInbound{dataDir: dataDir, client: client, logger: logger}
+}
+
+func (m *MailInbound) SocketPath() string {
+	return path.Join(m.dataDir, TunnelSocket)
+}
+
+func (m *MailInbound) Register() error {
+	socket := m.SocketPath()
+	m.logger.Info("registering the inbound mail socket", zap.String("socket", socket))
+	resp, err := m.client.Post("http://unix/mail/inbound/register",
+		url.Values{"socket": {socket}})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unable to register the inbound mail socket: %s %s",
+			resp.Status, string(body))
+	}
+	return nil
+}

--- a/cli/installer/mail_inbound.go
+++ b/cli/installer/mail_inbound.go
@@ -36,6 +36,10 @@ func (m *MailInbound) Register() error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		m.logger.Info("this platform does not take inbound mail registrations")
+		return nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unable to register the inbound mail socket: %s %s",

--- a/cli/installer/mail_inbound_test.go
+++ b/cli/installer/mail_inbound_test.go
@@ -1,0 +1,57 @@
+package installer
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type fakePlatform struct {
+	status int
+	posted url.Values
+	path   string
+}
+
+func (f *fakePlatform) Post(path string, values url.Values) (*http.Response, error) {
+	f.path = path
+	f.posted = values
+	return &http.Response{
+		StatusCode: f.status,
+		Status:     http.StatusText(f.status),
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func (f *fakePlatform) Get(_ string) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestMailInbound_RegistersTheSocket(t *testing.T) {
+	platform := &fakePlatform{status: http.StatusOK}
+	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+
+	assert.NoError(t, inbound.Register())
+
+	assert.Equal(t, "http://unix/mail/inbound/register", platform.path)
+	assert.Equal(t, "/var/snap/mail/current/spool/public/tunnel",
+		platform.posted.Get("socket"))
+}
+
+func TestMailInbound_OlderPlatformWithoutTheEndpointIsNotAFailure(t *testing.T) {
+	platform := &fakePlatform{status: http.StatusNotFound}
+	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+
+	assert.NoError(t, inbound.Register())
+}
+
+func TestMailInbound_ReportsOtherFailures(t *testing.T) {
+	platform := &fakePlatform{status: http.StatusInternalServerError}
+	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+
+	assert.Error(t, inbound.Register())
+}

--- a/cli/installer/mail_inbound_test.go
+++ b/cli/installer/mail_inbound_test.go
@@ -1,57 +1,43 @@
 package installer
 
 import (
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/golib/platform"
 	"go.uber.org/zap"
 )
 
-type fakePlatform struct {
-	status int
-	posted url.Values
-	path   string
+type fakeRegistry struct {
+	err    error
+	socket string
 }
 
-func (f *fakePlatform) Post(path string, values url.Values) (*http.Response, error) {
-	f.path = path
-	f.posted = values
-	return &http.Response{
-		StatusCode: f.status,
-		Status:     http.StatusText(f.status),
-		Body:       io.NopCloser(strings.NewReader("")),
-	}, nil
-}
-
-func (f *fakePlatform) Get(_ string) (*http.Response, error) {
-	return nil, nil
+func (f *fakeRegistry) RegisterMailInbound(socket string) error {
+	f.socket = socket
+	return f.err
 }
 
 func TestMailInbound_RegistersTheSocket(t *testing.T) {
-	platform := &fakePlatform{status: http.StatusOK}
-	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+	registry := &fakeRegistry{}
+	inbound := NewMailInbound("/var/snap/mail/current", registry, zap.NewNop())
 
 	assert.NoError(t, inbound.Register())
 
-	assert.Equal(t, "http://unix/mail/inbound/register", platform.path)
-	assert.Equal(t, "/var/snap/mail/current/spool/public/tunnel",
-		platform.posted.Get("socket"))
+	assert.Equal(t, "/var/snap/mail/current/spool/public/tunnel", registry.socket)
 }
 
 func TestMailInbound_OlderPlatformWithoutTheEndpointIsNotAFailure(t *testing.T) {
-	platform := &fakePlatform{status: http.StatusNotFound}
-	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+	registry := &fakeRegistry{err: platform.ErrNotSupported}
+	inbound := NewMailInbound("/var/snap/mail/current", registry, zap.NewNop())
 
 	assert.NoError(t, inbound.Register())
 }
 
 func TestMailInbound_ReportsOtherFailures(t *testing.T) {
-	platform := &fakePlatform{status: http.StatusInternalServerError}
-	inbound := NewMailInbound("/var/snap/mail/current", platform, zap.NewNop())
+	registry := &fakeRegistry{err: fmt.Errorf("register mail inbound, 500 Internal Server Error")}
+	inbound := NewMailInbound("/var/snap/mail/current", registry, zap.NewNop())
 
 	assert.Error(t, inbound.Register())
 }

--- a/config/postfix/master.cf
+++ b/config/postfix/master.cf
@@ -14,6 +14,25 @@ smtp      inet  n       -       n       -       -       smtpd
 #smtpd     pass  -       -       n       -       -       smtpd
 #dnsblog   unix  -       -       n       -       0       dnsblog
 #tlsproxy  unix  -       -       n       -       0       tlsproxy
+# mail arriving from the internet through the relay tunnel.
+#
+# bound to loopback because frpc is the only thing that reaches it. mynetworks
+# trusts loopback, so it is emptied here: otherwise anything reaching this port
+# could relay to any destination.
+#
+# the milters are dropped because opendkim runs in sign and verify mode and
+# treats 127.0.0.1 as an internal host, so it would sign mail from the whole
+# internet with this device's key instead of verifying it.
+127.0.0.1:10025 inet n    -       n       -       -       smtpd
+  -o syslog_name=postfix/tunnel
+  -o mynetworks=
+  -o smtpd_relay_restrictions=reject_unauth_destination
+  -o smtpd_recipient_restrictions=
+  -o smtpd_sasl_auth_enable=no
+  -o smtpd_tls_security_level=none
+  -o smtpd_milters=
+  -o non_smtpd_milters=
+
 submission inet n       -       n       -       -       smtpd
   -o syslog_name=postfix/submission
 #  -o smtpd_tls_security_level=encrypt

--- a/config/postfix/master.cf
+++ b/config/postfix/master.cf
@@ -14,16 +14,7 @@ smtp      inet  n       -       n       -       -       smtpd
 #smtpd     pass  -       -       n       -       -       smtpd
 #dnsblog   unix  -       -       n       -       0       dnsblog
 #tlsproxy  unix  -       -       n       -       0       tlsproxy
-# mail arriving from the internet through the relay tunnel.
-#
-# bound to loopback because frpc is the only thing that reaches it. mynetworks
-# trusts loopback, so it is emptied here: otherwise anything reaching this port
-# could relay to any destination.
-#
-# the milters are dropped because opendkim runs in sign and verify mode and
-# treats 127.0.0.1 as an internal host, so it would sign mail from the whole
-# internet with this device's key instead of verifying it.
-127.0.0.1:10025 inet n    -       n       -       -       smtpd
+tunnel    unix  n       -       n       -       -       smtpd
   -o syslog_name=postfix/tunnel
   -o mynetworks=
   -o smtpd_relay_restrictions=reject_unauth_destination

--- a/test/test.py
+++ b/test/test.py
@@ -290,11 +290,19 @@ PHP = '/snap/mail/current/bin/php'
 def tunnel_smtp(device, conversation):
     code = (
         '<?php\n'
+        'function reply($f) {{\n'
+        '    $out = "";\n'
+        '    while (($l = fgets($f)) !== false) {{\n'
+        '        $out .= $l;\n'
+        '        if (strlen($l) < 4 || $l[3] != "-") break;\n'
+        '    }}\n'
+        '    return $out;\n'
+        '}}\n'
         '$f = stream_socket_client("unix://{0}", $errno, $error, 20);\n'
         'if (!$f) {{ echo "connect failed: " . $error; exit(1); }}\n'
-        '{1}'
         'stream_set_timeout($f, 20);\n'
-        'while (($line = fgets($f)) !== false) {{ echo $line; }}\n'
+        'echo reply($f);\n'
+        '{1}'
     ).format(TUNNEL_SOCKET, conversation)
     escaped = code.replace('$', '\\$').replace('"', '\\"')
     return device.run_ssh(
@@ -302,6 +310,10 @@ def tunnel_smtp(device, conversation):
 
 
 def send(line):
+    return 'fwrite($f, "{0}\\r\\n");\necho reply($f);\n'.format(line)
+
+
+def write(line):
     return 'fwrite($f, "{0}\\r\\n");\n'.format(line)
 
 
@@ -321,10 +333,9 @@ def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain
         + send('MAIL FROM:<outside@example.com>')
         + send('RCPT TO:<{0}@{1}>'.format(device_user, domain))
         + send('DATA')
-        + 'sleep(2);'
-        + send('Subject: tunnel-delivery')
-        + send('')
-        + send('through the tunnel')
+        + write('Subject: tunnel-delivery')
+        + write('')
+        + write('through the tunnel')
         + send('.')
         + send('QUIT')))
     assert 'queued' in out, out

--- a/test/test.py
+++ b/test/test.py
@@ -290,7 +290,8 @@ SMTP_TOOL = '/tmp/smtp'
 
 @pytest.fixture(scope="session")
 def smtp(device, device_host):
-    run_scp('{0}/../build/smtp root@{1}:{2}'.format(DIR, device_host, SMTP_TOOL))
+    run_scp('{0}/../build/smtp root@{1}:{2}'.format(DIR, device_host, SMTP_TOOL),
+            password=device.ssh_password)
     device.run_ssh('chmod +x {0}'.format(SMTP_TOOL))
     return SMTP_TOOL
 

--- a/test/test.py
+++ b/test/test.py
@@ -279,3 +279,81 @@ def assert_relayed(domain):
     messages = faker_messages(domain)
     assert len(messages) > 0, 'relay received nothing'
     return messages
+
+
+def tunnel_smtp(device, script):
+    return device.run_ssh(
+        "python3 - <<'TUNNEL'\n{0}\nTUNNEL".format(script), throw=False)
+
+
+def test_tunnel_port_is_loopback_only(device):
+    listening = device.run_ssh("ss -lnt | grep ':10025' || true", throw=False)
+    assert '10025' in listening, listening
+    # the internet reaches this port only through frpc, never directly
+    assert '0.0.0.0:10025' not in listening, listening
+    assert '*:10025' not in listening, listening
+
+
+def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain,
+                                         device_password):
+    before = get_message_count(app_domain, device_user, device_password)
+    out = tunnel_smtp(device, '''
+import smtplib
+from email.mime.text import MIMEText
+msg = MIMEText("through the tunnel")
+msg["Subject"] = "tunnel-delivery"
+msg["From"] = "outside@example.com"
+msg["To"] = "{user}@{domain}"
+s = smtplib.SMTP("127.0.0.1", 10025, timeout=20)
+s.sendmail("outside@example.com", ["{user}@{domain}"], msg.as_string())
+s.quit()
+print("SENT")
+'''.format(user=device_user, domain=domain))
+    assert 'SENT' in out, out
+
+    after = retry_func(
+        lambda: assert_arrived(app_domain, device_user, device_password, before),
+        message='tunnel delivery', retries=20, sleep=3)
+    assert after > before
+
+
+def assert_arrived(app_domain, device_user, device_password, before):
+    count = get_message_count(app_domain, device_user, device_password)
+    assert count > before, 'nothing arrived through the tunnel'
+    return count
+
+
+def test_tunnel_refuses_to_relay_elsewhere(device):
+    # mynetworks is emptied for this service, so loopback is not trusted and
+    # the port cannot be used to send mail to the rest of the world
+    out = tunnel_smtp(device, '''
+import smtplib
+s = smtplib.SMTP("127.0.0.1", 10025, timeout=20)
+s.ehlo()
+print("MAIL", s.mail("outside@example.com"))
+print("RCPT", s.rcpt("victim@example.com"))
+s.quit()
+''')
+    assert 'RCPT' in out, out
+    assert '554' in out or '550' in out, out
+
+
+def latest_message(app_domain, device_user, device_password):
+    server = imaplib.IMAP4_SSL(app_domain, ssl_context=(SSLContext(ssl.PROTOCOL_TLS)))
+    server.login(device_user, device_password)
+    server.select('inbox')
+    _, data = server.search(None, 'SUBJECT', '"tunnel-delivery"')
+    ids = data[0].split()
+    assert ids, 'the tunnel delivered message is not in the mailbox'
+    _, fetched = server.fetch(ids[-1], '(RFC822)')
+    server.logout()
+    return fetched[0][1].decode('utf-8', 'replace')
+
+
+def test_tunnel_does_not_sign_incoming_mail(app_domain, domain, device_user, device_password):
+    # opendkim treats 127.0.0.1 as internal and runs in sign and verify mode,
+    # so leaving its milter on this service would sign mail from the whole
+    # internet with this device's key and make forgeries look authenticated
+    message = latest_message(app_domain, device_user, device_password)
+    signed_by_us = 'd={0}'.format(domain)
+    assert signed_by_us not in message, message[:2000]

--- a/test/test.py
+++ b/test/test.py
@@ -284,19 +284,25 @@ def assert_relayed(domain):
 TUNNEL_SOCKET = '/var/snap/mail/current/spool/public/tunnel'
 
 
-@pytest.fixture(scope="session")
-def socat(device):
-    device.run_ssh(
-        'command -v socat || (apt-get update -qq && apt-get install -y -qq socat)',
-        throw=False)
-    installed = device.run_ssh('command -v socat', throw=False)
-    assert 'socat' in installed, installed
+PHP = '/snap/mail/current/bin/php'
 
 
-def tunnel_smtp(device, script):
+def tunnel_smtp(device, conversation):
+    code = (
+        '<?php\n'
+        '$f = stream_socket_client("unix://{0}", $errno, $error, 20);\n'
+        'if (!$f) {{ echo "connect failed: " . $error; exit(1); }}\n'
+        '{1}'
+        'stream_set_timeout($f, 20);\n'
+        'while (($line = fgets($f)) !== false) {{ echo $line; }}\n'
+    ).format(TUNNEL_SOCKET, conversation)
+    escaped = code.replace('$', '\\$').replace('"', '\\"')
     return device.run_ssh(
-        '{{ {0} }} | timeout 20 socat - UNIX-CONNECT:{1}'.format(script, TUNNEL_SOCKET),
-        throw=False)
+        "{0} <<'PHPEOF'\n{1}PHPEOF".format(PHP, escaped), throw=False)
+
+
+def send(line):
+    return 'fwrite($f, "{0}\\r\\n");\n'.format(line)
 
 
 def test_tunnel_listens_on_a_socket_not_a_port(device):
@@ -307,14 +313,20 @@ def test_tunnel_listens_on_a_socket_not_a_port(device):
     assert 'srw' in socket, socket
 
 
-def test_tunnel_delivers_to_a_local_user(socat, device, domain, device_user, app_domain,
+def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain,
                                          device_password):
     before = get_message_count(app_domain, device_user, device_password)
-    out = tunnel_smtp(device, '''
-printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<{user}@{domain}>\\r\\nDATA\\r\\n'
-sleep 2
-printf 'Subject: tunnel-delivery\\r\\nFrom: outside@example.com\\r\\nTo: {user}@{domain}\\r\\n\\r\\nthrough the tunnel\\r\\n.\\r\\nQUIT\\r\\n'
-'''.format(user=device_user, domain=domain))
+    out = tunnel_smtp(device, (
+        send('EHLO tunnel.test')
+        + send('MAIL FROM:<outside@example.com>')
+        + send('RCPT TO:<{0}@{1}>'.format(device_user, domain))
+        + send('DATA')
+        + 'sleep(2);'
+        + send('Subject: tunnel-delivery')
+        + send('')
+        + send('through the tunnel')
+        + send('.')
+        + send('QUIT')))
     assert 'queued' in out, out
 
     after = retry_func(
@@ -329,10 +341,12 @@ def assert_arrived(app_domain, device_user, device_password, before):
     return count
 
 
-def test_tunnel_refuses_to_relay_elsewhere(socat, device):
-    out = tunnel_smtp(device, '''
-printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<victim@example.com>\\r\\nQUIT\\r\\n'
-''')
+def test_tunnel_refuses_to_relay_elsewhere(device):
+    out = tunnel_smtp(device, (
+        send('EHLO tunnel.test')
+        + send('MAIL FROM:<outside@example.com>')
+        + send('RCPT TO:<victim@example.com>')
+        + send('QUIT')))
     assert '554' in out or '550' in out, out
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -283,7 +283,8 @@ def assert_relayed(domain):
 
 def tunnel_smtp(device, script):
     return device.run_ssh(
-        "python3 - <<'TUNNEL'\n{0}\nTUNNEL".format(script), throw=False)
+        'exec 3<>/dev/tcp/127.0.0.1/10025\n{0}timeout 15 cat <&3'.format(script),
+        throw=False)
 
 
 def test_tunnel_port_is_loopback_only(device):
@@ -297,18 +298,11 @@ def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain
                                          device_password):
     before = get_message_count(app_domain, device_user, device_password)
     out = tunnel_smtp(device, '''
-import smtplib
-from email.mime.text import MIMEText
-msg = MIMEText('through the tunnel')
-msg['Subject'] = 'tunnel-delivery'
-msg['From'] = 'outside@example.com'
-msg['To'] = '{user}@{domain}'
-s = smtplib.SMTP('127.0.0.1', 10025, timeout=20)
-s.sendmail('outside@example.com', ['{user}@{domain}'], msg.as_string())
-s.quit()
-print('SENT')
+printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<{user}@{domain}>\\r\\nDATA\\r\\n' >&3
+sleep 2
+printf 'Subject: tunnel-delivery\\r\\nFrom: outside@example.com\\r\\nTo: {user}@{domain}\\r\\n\\r\\nthrough the tunnel\\r\\n.\\r\\nQUIT\\r\\n' >&3
 '''.format(user=device_user, domain=domain))
-    assert 'SENT' in out, out
+    assert 'queued' in out, out
 
     after = retry_func(
         lambda: assert_arrived(app_domain, device_user, device_password, before),
@@ -324,14 +318,8 @@ def assert_arrived(app_domain, device_user, device_password, before):
 
 def test_tunnel_refuses_to_relay_elsewhere(device):
     out = tunnel_smtp(device, '''
-import smtplib
-s = smtplib.SMTP('127.0.0.1', 10025, timeout=20)
-s.ehlo()
-print('MAIL', s.mail('outside@example.com'))
-print('RCPT', s.rcpt('victim@example.com'))
-s.quit()
+printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<victim@example.com>\\r\\nQUIT\\r\\n' >&3
 ''')
-    assert 'RCPT' in out, out
     assert '554' in out or '550' in out, out
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,7 @@ from ssl import SSLContext
 from subprocess import check_output
 from syncloudlib.integration.hosts import add_host_alias
 from syncloudlib.integration.installer import local_install
+from syncloudlib.integration.ssh import run_scp
 
 from test.util.helper import retry_func
 
@@ -284,37 +285,22 @@ def assert_relayed(domain):
 TUNNEL_SOCKET = '/var/snap/mail/current/spool/public/tunnel'
 
 
-PHP = '/snap/mail/current/bin/php'
+SMTP_TOOL = '/tmp/smtp'
 
 
-def tunnel_smtp(device, conversation):
-    code = (
-        '<?php\n'
-        'function reply($f) {{\n'
-        '    $out = "";\n'
-        '    while (($l = fgets($f)) !== false) {{\n'
-        '        $out .= $l;\n'
-        '        if (strlen($l) < 4 || $l[3] != "-") break;\n'
-        '    }}\n'
-        '    return $out;\n'
-        '}}\n'
-        '$f = stream_socket_client("unix://{0}", $errno, $error, 20);\n'
-        'if (!$f) {{ echo "connect failed: " . $error; exit(1); }}\n'
-        'stream_set_timeout($f, 20);\n'
-        'echo reply($f);\n'
-        '{1}'
-    ).format(TUNNEL_SOCKET, conversation)
-    escaped = code.replace('$', '\\$').replace('"', '\\"')
-    return device.run_ssh(
-        "{0} <<'PHPEOF'\n{1}PHPEOF".format(PHP, escaped), throw=False)
+@pytest.fixture(scope="session")
+def smtp(device, device_host):
+    run_scp('{0}/../build/smtp root@{1}:{2}'.format(DIR, device_host, SMTP_TOOL))
+    device.run_ssh('chmod +x {0}'.format(SMTP_TOOL))
+    return SMTP_TOOL
 
 
-def send(line):
-    return 'fwrite($f, "{0}\\r\\n");\necho reply($f);\n'.format(line)
-
-
-def write(line):
-    return 'fwrite($f, "{0}\\r\\n");\n'.format(line)
+def tunnel_smtp(device, sender, recipient, subject='', body=''):
+    command = "{0} -socket {1} -from '{2}' -rcpt '{3}'".format(
+        SMTP_TOOL, TUNNEL_SOCKET, sender, recipient)
+    if subject:
+        command += " -subject '{0}' -body '{1}'".format(subject, body)
+    return device.run_ssh(command, throw=False)
 
 
 def test_tunnel_listens_on_a_socket_not_a_port(device):
@@ -325,19 +311,11 @@ def test_tunnel_listens_on_a_socket_not_a_port(device):
     assert 'srw' in socket, socket
 
 
-def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain,
+def test_tunnel_delivers_to_a_local_user(smtp, device, domain, device_user, app_domain,
                                          device_password):
     before = get_message_count(app_domain, device_user, device_password)
-    out = tunnel_smtp(device, (
-        send('EHLO tunnel.test')
-        + send('MAIL FROM:<outside@example.com>')
-        + send('RCPT TO:<{0}@{1}>'.format(device_user, domain))
-        + send('DATA')
-        + write('Subject: tunnel-delivery')
-        + write('')
-        + write('through the tunnel')
-        + send('.')
-        + send('QUIT')))
+    out = tunnel_smtp(device, 'outside@example.com', '{0}@{1}'.format(device_user, domain),
+                      subject='tunnel-delivery', body='through the tunnel')
     assert 'queued' in out, out
 
     after = retry_func(
@@ -352,12 +330,8 @@ def assert_arrived(app_domain, device_user, device_password, before):
     return count
 
 
-def test_tunnel_refuses_to_relay_elsewhere(device):
-    out = tunnel_smtp(device, (
-        send('EHLO tunnel.test')
-        + send('MAIL FROM:<outside@example.com>')
-        + send('RCPT TO:<victim@example.com>')
-        + send('QUIT')))
+def test_tunnel_refuses_to_relay_elsewhere(smtp, device):
+    out = tunnel_smtp(device, 'outside@example.com', 'victim@example.com')
     assert '554' in out or '550' in out, out
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -281,26 +281,39 @@ def assert_relayed(domain):
     return messages
 
 
+TUNNEL_SOCKET = '/var/snap/mail/current/spool/public/tunnel'
+
+
+@pytest.fixture(scope="session")
+def socat(device):
+    device.run_ssh(
+        'command -v socat || (apt-get update -qq && apt-get install -y -qq socat)',
+        throw=False)
+    installed = device.run_ssh('command -v socat', throw=False)
+    assert 'socat' in installed, installed
+
+
 def tunnel_smtp(device, script):
     return device.run_ssh(
-        'exec 3<>/dev/tcp/127.0.0.1/10025\n{0}timeout 15 cat <&3'.format(script),
+        '{{ {0} }} | timeout 20 socat - UNIX-CONNECT:{1}'.format(script, TUNNEL_SOCKET),
         throw=False)
 
 
-def test_tunnel_port_is_loopback_only(device):
-    listening = device.run_ssh("ss -lnt | grep ':10025' || true", throw=False)
-    assert '10025' in listening, listening
-    assert '0.0.0.0:10025' not in listening, listening
-    assert '*:10025' not in listening, listening
+def test_tunnel_listens_on_a_socket_not_a_port(device):
+    listening = device.run_ssh("ss -lnt || true", throw=False)
+    assert ':10025' not in listening, listening
+
+    socket = device.run_ssh("ls -l {0}".format(TUNNEL_SOCKET), throw=False)
+    assert 'srw' in socket, socket
 
 
-def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain,
+def test_tunnel_delivers_to_a_local_user(socat, device, domain, device_user, app_domain,
                                          device_password):
     before = get_message_count(app_domain, device_user, device_password)
     out = tunnel_smtp(device, '''
-printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<{user}@{domain}>\\r\\nDATA\\r\\n' >&3
+printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<{user}@{domain}>\\r\\nDATA\\r\\n'
 sleep 2
-printf 'Subject: tunnel-delivery\\r\\nFrom: outside@example.com\\r\\nTo: {user}@{domain}\\r\\n\\r\\nthrough the tunnel\\r\\n.\\r\\nQUIT\\r\\n' >&3
+printf 'Subject: tunnel-delivery\\r\\nFrom: outside@example.com\\r\\nTo: {user}@{domain}\\r\\n\\r\\nthrough the tunnel\\r\\n.\\r\\nQUIT\\r\\n'
 '''.format(user=device_user, domain=domain))
     assert 'queued' in out, out
 
@@ -316,9 +329,9 @@ def assert_arrived(app_domain, device_user, device_password, before):
     return count
 
 
-def test_tunnel_refuses_to_relay_elsewhere(device):
+def test_tunnel_refuses_to_relay_elsewhere(socat, device):
     out = tunnel_smtp(device, '''
-printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<victim@example.com>\\r\\nQUIT\\r\\n' >&3
+printf 'EHLO tunnel.test\\r\\nMAIL FROM:<outside@example.com>\\r\\nRCPT TO:<victim@example.com>\\r\\nQUIT\\r\\n'
 ''')
     assert '554' in out or '550' in out, out
 

--- a/test/test.py
+++ b/test/test.py
@@ -289,7 +289,6 @@ def tunnel_smtp(device, script):
 def test_tunnel_port_is_loopback_only(device):
     listening = device.run_ssh("ss -lnt | grep ':10025' || true", throw=False)
     assert '10025' in listening, listening
-    # the internet reaches this port only through frpc, never directly
     assert '0.0.0.0:10025' not in listening, listening
     assert '*:10025' not in listening, listening
 
@@ -300,14 +299,14 @@ def test_tunnel_delivers_to_a_local_user(device, domain, device_user, app_domain
     out = tunnel_smtp(device, '''
 import smtplib
 from email.mime.text import MIMEText
-msg = MIMEText("through the tunnel")
-msg["Subject"] = "tunnel-delivery"
-msg["From"] = "outside@example.com"
-msg["To"] = "{user}@{domain}"
-s = smtplib.SMTP("127.0.0.1", 10025, timeout=20)
-s.sendmail("outside@example.com", ["{user}@{domain}"], msg.as_string())
+msg = MIMEText('through the tunnel')
+msg['Subject'] = 'tunnel-delivery'
+msg['From'] = 'outside@example.com'
+msg['To'] = '{user}@{domain}'
+s = smtplib.SMTP('127.0.0.1', 10025, timeout=20)
+s.sendmail('outside@example.com', ['{user}@{domain}'], msg.as_string())
 s.quit()
-print("SENT")
+print('SENT')
 '''.format(user=device_user, domain=domain))
     assert 'SENT' in out, out
 
@@ -324,14 +323,12 @@ def assert_arrived(app_domain, device_user, device_password, before):
 
 
 def test_tunnel_refuses_to_relay_elsewhere(device):
-    # mynetworks is emptied for this service, so loopback is not trusted and
-    # the port cannot be used to send mail to the rest of the world
     out = tunnel_smtp(device, '''
 import smtplib
-s = smtplib.SMTP("127.0.0.1", 10025, timeout=20)
+s = smtplib.SMTP('127.0.0.1', 10025, timeout=20)
 s.ehlo()
-print("MAIL", s.mail("outside@example.com"))
-print("RCPT", s.rcpt("victim@example.com"))
+print('MAIL', s.mail('outside@example.com'))
+print('RCPT', s.rcpt('victim@example.com'))
 s.quit()
 ''')
     assert 'RCPT' in out, out
@@ -351,9 +348,6 @@ def latest_message(app_domain, device_user, device_password):
 
 
 def test_tunnel_does_not_sign_incoming_mail(app_domain, domain, device_user, device_password):
-    # opendkim treats 127.0.0.1 as internal and runs in sign and verify mode,
-    # so leaving its milter on this service would sign mail from the whole
-    # internet with this device's key and make forgeries look authenticated
     message = latest_message(app_domain, device_user, device_password)
     signed_by_us = 'd={0}'.format(domain)
     assert signed_by_us not in message, message[:2000]


### PR DESCRIPTION
Mail app side of inbound mail. Completes the chain with syncloud/redirect#63
(terminates port 25, forwards down the tunnel) and syncloud/platform#762
(asks frps for the proxy that carries it).

redirect forwards each message down the frp tunnel, which arrives at the
device on loopback. Postfix needs somewhere to put it that is not the port it
already offers the internet, so this adds an smtpd on `127.0.0.1:10025` — the
port the platform's frpc proxy forwards to.

## Two defaults that had to be turned off

**mynetworks trusts loopback**, and everything through the tunnel arrives from
loopback. Left alone, this port would relay to any destination for anyone who
reached it. Emptied for this service, with a test that it refuses.

**The milters had to go too, and this is the one that would have been quiet.**
opendkim runs `Mode sv` with `127.0.0.1` in `TrustedHosts`, so it classifies
tunnel traffic as *internal*. It would have signed mail from the whole
internet with this device's key instead of verifying it, and forged mail would
have landed in the user's mailbox looking DKIM-authenticated as their own
domain. rspamd does its own verification when it lands, so nothing is lost by
dropping them here.

## Tests

Delivery to a local mailbox through the tunnel port, the port staying on
loopback rather than facing the internet, the relay refusal, and that a
delivered message carries no signature of ours.

## Not covered here

rspamd and redis are not packaged yet, so inbound mail is unfiltered: nothing
scans it, and there is no Junk folder to file it into. dovecot sieve is not
enabled either. That is the larger piece of work and wants its own branch —
this one is the part that makes the tunnel deliver at all.

Port 10025 is the contract with the platform side; it appears there as
`config.MailInboundPort`.