### PR TITLE
Take the word of a forwarder that vouches for what it passes on

### DIFF
--- a/config/rspamd/local.d/arc.conf
+++ b/config/rspamd/local.d/arc.conf
@@ -1,0 +1,12 @@
+whitelisted_signers_map = [
+  "messagingengine.com",
+  "google.com",
+  "microsoft.com",
+  "icloud.com",
+  "yahooinc.com",
+  "proton.me",
+  "protonmail.ch",
+  "mailbox.org",
+  "zoho.com",
+  "forwardemail.net",
+];

--- a/config/rspamd/local.d/policies_group.conf
+++ b/config/rspamd/local.d/policies_group.conf
@@ -1,0 +1,8 @@
+symbols {
+  "ARC_ALLOW_TRUSTED" {
+    weight = -4.0;
+    one_shot = true;
+    description = "ARC chain sealed by a forwarder we trust";
+    groups = ["arc"];
+  }
+}

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,5 @@
 import imaplib
+import json
 import os
 import pytest
 import requests
@@ -367,6 +368,20 @@ def test_rspamd_and_redis_listen_on_sockets(device, data_dir):
 
     redis = device.run_ssh("ls -l {0}/redis/redis.sock".format(data_dir), throw=False)
     assert 'srw' in redis, redis
+
+
+def test_arc_from_a_trusted_forwarder_offsets_the_forwarding_penalty(device, data_dir):
+    password = device.run_ssh("cat {0}/rspamd/password".format(data_dir), throw=False).strip()
+    symbols = device.run_ssh(
+        "curl -s --unix-socket {0}/rspamd/controller.sock -H 'Password: {1}' "
+        "http://localhost/symbols".format(data_dir, password), throw=False)
+    trusted = [rule
+               for group in json.loads(symbols)
+               for rule in group.get('rules', [])
+               if rule.get('symbol') == 'ARC_ALLOW_TRUSTED']
+    assert trusted, symbols[:2000]
+    for rule in trusted:
+        assert rule['weight'] == -4.0, rule
 
 
 def test_tunnel_takes_the_announced_client_address(smtp, device, domain, device_user):


### PR DESCRIPTION
## What

Wires rspamd's `arc` module to a list of forwarders we trust, and weights the resulting `ARC_ALLOW_TRUSTED` at −4.0 so a proven forwarding chain refunds the penalty that forwarding itself creates.

## Why

Forwarded mail cannot pass SPF. The envelope still names the original sender while the connection comes from the forwarder, so the check fails by construction. On a live device this alone was carrying ordinary mail into Junk:

| symbol | score |
|---|---|
| `VIOLATED_DIRECT_SPF` | +3.5 |
| `R_SPF_FAIL` | +1.0 |
| `FORGED_RECIPIENTS` | +2.0 |
| `ARC_ALLOW` | −1.0 |

Against `add_header = 6`, every message forwarded into the box scored 6.2–8.1 and was filed as spam for reasons that had nothing to do with its content — including Syncloud's own transactional mail and inbound user support reports.

## How

The `arc` module already verifies these chains (`ARC_ALLOW` was firing at −1.0, nowhere near the +4.5 SPF penalty). Setting `whitelisted_signers_map` turns on `ARC_ALLOW_TRUSTED`, and the module respects what the seal itself admits — half credit where the forwarder recorded SPF fail, none where it recorded a DMARC reject — so trust never outruns what was actually vouched for.

`one_shot = true` matters: rspamd inserts the symbol **once per seal in the chain**, so without it a 2-hop chain scored −8 and a 4-hop chain −12. Unbounded, and a long enough chain buys past anything.

## Measured

On nine real false positives from one day, rescanned with our own `X-Spam: Yes` stripped so the numbers aren't self-contaminated:

| message | before | after |
|---|---|---|
| Device error report (×4) | 7.11–8.07 | −0.19 … +0.47 |
| Syncloud free trial expires in 10 days | 7.41 | −0.19 |
| Jellyin can't be installed anymore | 6.21 | −1.09 |
| Syncloud account removed | 7.41 | −0.19 |

## Tests

The added test asserts the symbol is registered at the intended weight rather than exercising the scoring, there being no way to forge a chain that a signer we trust would have sealed.

## Note

Removing the forwarding penalty means forwarded spam now has to be caught on its own merits. Bayes on a fresh device is untrained (200 learns required), so marking spam in Roundcube is what closes that gap.