### PR TITLE
Stop asking rspamd to save a cache it cannot write

### DIFF
--- a/config/rspamd/local.d/options.inc
+++ b/config/rspamd/local.d/options.inc
@@ -1,0 +1,1 @@
+cache_file = null;

--- a/test/test.py
+++ b/test/test.py
@@ -370,6 +370,27 @@ def test_rspamd_and_redis_listen_on_sockets(device, data_dir):
     assert 'srw' in redis, redis
 
 
+def rspamd_cache_complaints(device, data_dir):
+    out = device.run_ssh("grep -c save_items {0}/log/rspamd.log || true".format(data_dir), throw=False)
+    return int(out.strip() or 0)
+
+
+def test_rspamd_shutdown_does_not_complain_about_the_symbol_cache(device, data_dir):
+    before = rspamd_cache_complaints(device, data_dir)
+    device.run_ssh("snap restart mail.rspamd", throw=False)
+    retry_func(lambda: assert_rspamd_answers(device, data_dir),
+               message='rspamd back after restart', retries=20, sleep=3)
+
+    assert rspamd_cache_complaints(device, data_dir) == before
+
+
+def assert_rspamd_answers(device, data_dir):
+    out = device.run_ssh(
+        "curl -s --unix-socket {0}/rspamd/controller.sock http://localhost/ping".format(data_dir),
+        throw=False)
+    assert 'pong' in out, out
+
+
 def test_arc_from_a_trusted_forwarder_offsets_the_forwarding_penalty(device, data_dir):
     password = device.run_ssh("cat {0}/rspamd/password".format(data_dir), throw=False).strip()
     symbols = device.run_ssh(


### PR DESCRIPTION
## The error

Every rspamd shutdown since the filter landed has logged:

```
symcache; save_items: cannot create file /var/snap/mail/447/rspamd/symbols.cache.new: No such file or directory
```

## Root cause

rspamd 3.4 writes the symbol cache by opening `<cache_file>.new` with flags that do **not** include `O_CREAT`. A missing temp file therefore returns `ENOENT`, which the code reports as "cannot create file". On this snap `symbols.cache` has never existed, so it failed on every single shutdown.

Everything that looks like the obvious cause was ruled out first:

- the directory exists and is writable by `mail` — verified from outside, inside the service's mount namespace (`nsenter`), and inside the snap's own AppArmor confinement (`snap run --shell mail.rspamd`)
- rspamd concurrently writes `rspamd.rrd`, `stats.ucl` and its hyperscan caches into that same directory
- no chroot (`/proc/<pid>/root -> /`), no AppArmor denials, strict confinement

Proven by A/B on a device — restart with the temp file absent vs. pre-created:

| | delta in error count |
|---|---|
| `.new` absent | **+1** |
| `.new` pre-created | **0** |

## Why not just pre-create the temp file

Tested, and rejected. The error goes away, but afterwards *both* files are gone and no cache is ever produced — rspamd consumes the temp file and writes nothing. That silences the log line while leaving the feature exactly as broken, which is worse than the honest state: the next person reads a clean log and assumes the cache works.

## The fix

`cache_file = null` makes `save_items` return before it attempts anything. We state that we don't persist the symbol cache instead of trying and failing once per restart. The only cost is the cross-restart symbol-ordering optimisation, which was never actually being persisted — so nothing is lost in practice, and the ordering is recomputed at every start as it already was.

Verified on a device: three consecutive restarts with zero errors, `ARC_ALLOW_TRUSTED` still registered at −4.0, forwarded mail still scoring −3.99 `no action`, scanning healthy.

## Test

Counts the complaints either side of a restart rather than asserting the log is silent — a device upgraded from a revision that left old errors behind would fail the naive version during `test-upgrade`.

Validated both ways on a real device:

```
WITH fix     before=9  after=9   delta=0   (passes)
WITHOUT fix  before=9  after=10  delta=1   (fails)
restored     before=11 after=11  delta=0   (passes)
```