### PR TITLE
Stop running the neural filter we cannot feed

### DIFF
--- a/config/rspamd/local.d/neural.conf
+++ b/config/rspamd/local.d/neural.conf
@@ -1,0 +1,1 @@
+enabled = false;

--- a/test/test.py
+++ b/test/test.py
@@ -391,18 +391,26 @@ def assert_rspamd_answers(device, data_dir):
     assert 'pong' in out, out
 
 
-def test_arc_from_a_trusted_forwarder_offsets_the_forwarding_penalty(device, data_dir):
+def rspamd_symbols(device, data_dir):
     password = device.run_ssh("cat {0}/rspamd/password".format(data_dir), throw=False).strip()
     symbols = device.run_ssh(
         "curl -s --unix-socket {0}/rspamd/controller.sock -H 'Password: {1}' "
         "http://localhost/symbols".format(data_dir, password), throw=False)
-    trusted = [rule
-               for group in json.loads(symbols)
-               for rule in group.get('rules', [])
+    return [rule for group in json.loads(symbols) for rule in group.get('rules', [])]
+
+
+def test_arc_from_a_trusted_forwarder_offsets_the_forwarding_penalty(device, data_dir):
+    trusted = [rule for rule in rspamd_symbols(device, data_dir)
                if rule.get('symbol') == 'ARC_ALLOW_TRUSTED']
-    assert trusted, symbols[:2000]
+    assert trusted, 'ARC_ALLOW_TRUSTED is not registered'
     for rule in trusted:
         assert rule['weight'] == -4.0, rule
+
+
+def test_neural_is_not_running(device, data_dir):
+    neural = sorted({rule['symbol'] for rule in rspamd_symbols(device, data_dir)
+                     if rule.get('symbol', '').startswith('NEURAL')})
+    assert neural == [], neural
 
 
 def test_tunnel_takes_the_announced_client_address(smtp, device, domain, device_user):


### PR DESCRIPTION
## The error

```
neural.lua:767: cannot parse profile schema: extra fields: table: 0x7fdad4877fa0
```

rspamd's neural module stores its ANN profile in Redis and validates it against a strict schema on load (`digest`, `symbols`, `version`, `redis_key`, optional `distance`). It rejected its own stored profile as having extra fields.

## What I found

Being straight about the limits of the diagnosis: **I could not reproduce the malformed profile.** I pulled the profile currently in Redis and ran it through the exact same schema under `rspamadm lua`:

```
keys: digest(string), distance(number), redis_key(string), symbols(table), version(number)
SCHEMA OK
```

It validates. Only one profile exists in the zset, so the one that failed has since been overwritten and is unrecoverable. I am not going to invent a root cause for a one-shot in an upstream module whose evidence no longer exists.

What that investigation did establish is the more useful fact: **this module cannot work here and never has.**

- it needs `max_trains = 1000` samples *per class* before it produces a verdict; this device has **15 ham / 8 spam**
- across all 23 messages in the scan history, `NEURAL_HAM`/`NEURAL_SPAM` fired **zero times**
- nothing in this repo ever configured it — it is simply on by default in this rspamd build
- meanwhile it accumulates training vectors in Redis and, at least once, logged an error

## The fix

Turn it off explicitly. Same reasoning as the symbol cache in #8: don't run a subsystem we neither opted into nor can feed, and stop the errors at their source rather than filtering them out of the log.

Since it never contributed a symbol, scoring is unaffected — verified before and after that `ARC_ALLOW_TRUSTED` is still registered at −4.0 and rspamd answers normally.

The vectors already in Redis are left alone; they are small and unread once the module is off. Say the word if you'd rather they were cleaned out.

## Tests

`test_neural_is_not_running` asserts no `NEURAL*` symbol is registered. Both this and the existing ARC test ask the controller the same question, so they now share a `rspamd_symbols` helper instead of duplicating the curl.

A/B on a real device:

```
WITH neural.conf     neural=[]                                arc=-4.0   (passes)
WITHOUT neural.conf  neural=[NEURAL_HAM NEURAL_SPAM]          arc=-4.0   (fails)
restored             neural=[]                                arc=-4.0   (passes)
```