### PR TITLE
Leave the signing to opendkim

### DIFF
--- a/config/rspamd/local.d/dkim_signing.conf
+++ b/config/rspamd/local.d/dkim_signing.conf
@@ -1,0 +1,1 @@
+enabled = false;

--- a/test/test.py
+++ b/test/test.py
@@ -407,6 +407,12 @@ def test_arc_from_a_trusted_forwarder_offsets_the_forwarding_penalty(device, dat
         assert rule['weight'] == -4.0, rule
 
 
+def test_rspamd_checks_dkim_but_leaves_the_signing_to_opendkim(device, data_dir):
+    registered = {rule.get('symbol') for rule in rspamd_symbols(device, data_dir)}
+    assert 'R_DKIM_ALLOW' in registered, 'dkim checking is gone'
+    assert 'DKIM_SIGNED' not in registered, 'rspamd is still set up to sign'
+
+
 def test_neural_is_not_running(device, data_dir):
     neural = sorted({rule['symbol'] for rule in rspamd_symbols(device, data_dir)
                      if rule.get('symbol', '').startswith('NEURAL')})


### PR DESCRIPTION
## The error

```
dkim_module_load_key_format: cannot load dkim key /var/snap/mail/454/rspamd/dkim/paypal.co.uk.dkim.key: No such file or directory
```

Eight occurrences since rev 443, for four different domains: `syncloud.it`, `example.net`, `gmail.com`, `paypal.co.uk`.

## What is happening

rspamd's `dkim_signing` module is on by default with `sign_local = true`, `sign_authenticated = true` and `use_domain = "header"`. So whenever it considers a message local, it reaches for a signing key **named after the From: header domain** — which for inbound mail is the sender's domain, not ours. It was asking to sign other people's incoming mail as them.

It has never had a key and never will, because on this device signing belongs to opendkim:

| postfix path | milters |
|---|---|
| `submission` + local injection (`non_smtpd_milters`) | **opendkim only** — rspamd never sees outbound mail |
| `smtp` (port 25) | opendkim + rspamd |
| `tunnel` (relay) | rspamd only |

rspamd is handed inbound mail exclusively. There is nothing for it to sign.

Real inbound mail arrives with a genuine remote IP via XCLIENT, so it isn't "local" and no attempt is made — which is why the log hits are only loopback-origin test messages and manual `rspamc` file scans (which have no IP at all). Harmless in production, but it is a module reaching for keys it should never want, and the noise obscures real problems.

## The fix

Disable the signing module. The **checking** module is separate and untouched — the test asserts both halves so that disabling the wrong one is caught:

```python
assert 'R_DKIM_ALLOW' in registered     # checking still there
assert 'DKIM_SIGNED' not in registered  # signing gone
```

## Verified on a device

Reproduced first: rescanning the paypal message reliably added exactly one error (`delta=1`). After disabling, the same rescan adds none (`delta=0`).

- `DKIM_SIGNED` deregistered; `R_DKIM_ALLOW` and `ARC_ALLOW_TRUSTED` still registered
- DKIM verification still fires on real mail — `R_DKIM_ALLOW (-0.20)[syncloud.it:s=…, amazonses.com:s=…]` with `DKIM_TRACE`
- opendkim service untouched and active

**Scoring impact: none.** A/B'd the same message with the module enabled and disabled:

```
dkim_signing DISABLED   Score: 0.81
dkim_signing ENABLED    Score: 0.81
restored DISABLED       Score: 0.81
```

(That message read −0.19 in an earlier session and 0.81 now. The whole difference is `DATE_IN_PAST (1.00)[50]` — it is a rescan of a message that is now 50 hours old. Unrelated to this change, as the A/B above shows.)